### PR TITLE
Simplify package installation commands in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,9 @@ git clone https://github.com/daspartho/SpotiByeAds.git
 cd SpotiByeAds.py
 ```
 ```
-pip install pynput
+pip install pynput spotipy
 ```
-```
-pip install spotipy
-```
+
 
 ### Setting up
 


### PR DESCRIPTION
Since this is a small change I decided to make a PR instead of making an issue. Replaced `pip install pynput` and `pip install spotipy` with one line `pip install pynput spotipy`.