### PR TITLE
Fix issue of same song repeating after skipping ad

### DIFF
--- a/main.py
+++ b/main.py
@@ -12,8 +12,8 @@ def openSpotify(path):
 
 def playSpotify():
     keyboard = Controller()
-    keyboard.press(Key.media_play_pause)
-    keyboard.release(Key.media_play_pause)
+    keyboard.press(Key.media_next)
+    keyboard.release(Key.media_next)
     
 def previousWindow():
     keyboard = Controller()


### PR DESCRIPTION
I noticed that when the program detected an ad and restarted spotify, the same song that was playing before the ad would be played again. This fixes the issue by hitting the "next" key instead of the "play/pause" key when restarting spotify.

I should clarify that I got spotify from the Microsoft Store and it's possible that the official spotify desktop app doesn't have this issue. In this case, you may want to create a separate version for users who got it from the Microsoft Store which addresses both this issue and Issue #2.