### PR TITLE
added one time, interactive set up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,140 @@
+credentials.json
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 credentials.json
+.cache-*
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@ import os
 import spotipy
 from spotipy import util
 from pynput.keyboard import Key, Controller
+import json
 
 def closeSpotify():
     os.system("taskkill /f /im spotify.exe")
@@ -56,12 +57,31 @@ def main(username, scope, clientID, clientSecret, redirectURI, path):
 
 if __name__ == '__main__':
     
-    PATH = ''
-    spotifyUsername = ""
-    spotifyClientID = ""
-    spotifyClientSecret = ""
-    spotifyAccessScope = "user-read-currently-playing"
-    spotifyRedirectURI = "http://localhost:8080/"
+    try:
+        with open("credentials.json", "r") as credentials_json:
+            credentials = json.load(credentials_json)
+            PATH = credentials["PATH"]
+            spotify_username = credentials["spotify_username"]
+            spotify_client_id = credentials["spotify_client_id"]
+            spotify_client_secret = credentials["spotify_client_secret"]
+            ACCESS_SCOPE = credentials["ACCESS_SCOPE"]
+            REDIRECT_URI = credentials["REDIRECT_URI"]
+    except FileNotFoundError:
+        print("SpotiByeAds setup:")
+        
+        PATH = input("Where is your Spotify.exe located? ")
+        spotify_username = input("What is your Spotify username? ")
+        spotify_client_id = input("What is your Client ID? ")
+        spotify_client_secret = input("What is your Client Secret? ")
+        ACCESS_SCOPE = "user-read-currently-playing"
+        REDIRECT_URI = "http://localhost:8080/"
 
-    main(spotifyUsername, spotifyAccessScope, spotifyClientID, spotifyClientSecret, spotifyRedirectURI, PATH)
+        spotify_credentials = {"PATH":PATH, "spotify_username":spotify_username, "spotify_client_id":spotify_client_id, "spotify_client_secret":spotify_client_secret, "ACCESS_SCOPE":ACCESS_SCOPE, "REDIRECT_URI":REDIRECT_URI}
+        
+        with open("credentials.json", "w") as credentials:
+            credentials.write(json.dumps(spotify_credentials))
+
+
+
+    main(spotify_username, ACCESS_SCOPE, spotify_client_id, spotify_client_secret, REDIRECT_URI, PATH)
 


### PR DESCRIPTION
I added a one time, interactive set up. This way you don't have to edit the code to insert you client id, client secret, etc.
Up on running the program for the first time you get asked to in put these credentials. These values then get saved to a `credentials.json` in the root directory of the program. The next time the program is launched it takes the credentials from the file and doesn't ask for them.

I also added a `.gitignore` file to not leak my `credentials.json` file