### PR TITLE
Use `sys.platform` instead of `os.name` #23

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,7 +3,7 @@ from os import error
 
 while True: #If we get no import errors then break from the loop. If we do get an error install the dependencies and do the try/catch block again.
      try:
-         import os,time,shutil,subprocess,json #Base Libs
+         import os,sys,time,shutil,subprocess,json #Base Libs
          import spotipy
          from spotipy import util, SpotifyException
          from pynput.keyboard import Key, Controller
@@ -18,20 +18,17 @@ while True: #If we get no import errors then break from the loop. If we do get a
 keyboard = Controller() #I noticed how we kept making a new keyboard controller instance so decided to just make it a variable
 
 def closeSpotify():
-    if os.name == "nt":
-        # windows
-            os.system("taskkill /f /im spotify.exe")
-    elif os.name == "posix":
-        # macos
+    if sys.platform == "win32":  # windows
+        os.system("taskkill /f /im spotify.exe")
+    elif sys.platform == "darwin":  # macos
         os.system("kill -9 13068")
-    else:
-        # almost everything else
+    else:  # almost everything else
         os.system("killall -9 spotify")
 
 def openSpotify(path):
     if path is None:
         path = shutil.which("spotify")
-    if path is None and os.name == "posix":
+    if path is None and sys.platform == "darwin":
         path = "/Applications/Spotify.app"
 
     subprocess.Popen([path], start_new_session=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, shell=True)
@@ -126,4 +123,3 @@ if __name__ == '__main__':
             print("Didn't recognize input, defaulted to not saving.")
 
     main(spotify_username, spotifyAccessScope, spotify_client_id, spotify_client_secret, spotifyRedirectURI, PATH)
-


### PR DESCRIPTION
Use `sys.platform` instead of `os.name` (#23). Potentially fixes #21 as well, but have not tested this.